### PR TITLE
Added the effect of "critical hit when hitting the head".

### DIFF
--- a/src/battle_game/core/CMakeLists.txt
+++ b/src/battle_game/core/CMakeLists.txt
@@ -3,7 +3,7 @@ list(APPEND LIBRARY_LIST ${lib_name})
 
 add_library(${lib_name})
 file(GLOB_RECURSE source_files *.cpp *.h)
-target_sources(${lib_name} PUBLIC ${source_files})
+target_sources(${lib_name} PUBLIC ${source_files} "bullets/by_chance_bullet.cpp" "bullets/by_chance_bullet.h")
 target_link_libraries(${lib_name} PUBLIC grassland)
 target_include_directories(${lib_name} PUBLIC ${BATTLE_GAME_EXTERNAL_INCLUDE_DIRS} ${BATTLE_GAME_INCLUDE_DIR})
 

--- a/src/battle_game/core/bullets/bullets.h
+++ b/src/battle_game/core/bullets/bullets.h
@@ -1,2 +1,3 @@
 #pragma once
 #include "battle_game/core/bullets/cannon_ball.h"
+#include "battle_game/core/bullets/by_chance_bullet.h"

--- a/src/battle_game/core/bullets/by_chance_bullet.cpp
+++ b/src/battle_game/core/bullets/by_chance_bullet.cpp
@@ -1,0 +1,58 @@
+#include "battle_game/core/bullets/by_chance_bullet.h"
+#include "battle_game/core/game_core.h"
+#include "battle_game/core/particles/particles.h"
+namespace battle_game::bullet {
+StrangeBall::StrangeBall(GameCore *core,
+                       uint32_t id,
+                       uint32_t unit_id,
+                       uint32_t player_id,
+                       glm::vec2 position,
+                       float rotation,
+                       float damage_scale,
+                       glm::vec2 velocity)
+    : Bullet(core, id, unit_id, player_id, position, rotation, damage_scale),
+      velocity_(velocity) {
+}
+void StrangeBall::Render() {
+  SetTransformation(position_, rotation_, glm::vec2{0.1f});
+  SetColor(game_core_->GetPlayerColor(player_id_));
+  SetTexture(BATTLE_GAME_ASSETS_DIR "textures/particle3.png");
+  DrawModel(0);
+}
+float ComputeScale(glm::vec2 position) {
+  if (position.y > 0.8f)
+    return 2.0;
+  else
+    return 1.0;
+}
+void StrangeBall::Update() {
+  position_ += velocity_ * kSecondPerTick;
+  bool should_die = false;
+  if (game_core_->IsBlockedByObstacles(position_)) {
+    should_die = true;
+  }
+  auto &units = game_core_->GetUnits();
+  for (auto &unit : units) {
+    if (unit.first == unit_id_) {
+      continue;
+    }
+    if (unit.second->IsHit(position_)) {
+      float damage = damage_scale_;
+      if (unit.second->WorldToLocal(position_).y > 0.8f)
+        damage *= 2.0;
+      game_core_->PushEventDealDamage(unit.first, id_, damage * 10.0f);
+      should_die = true;
+    }
+  }
+  if (should_die) {
+    game_core_->PushEventRemoveBullet(id_);
+  }
+}
+StrangeBall::~StrangeBall() {
+  for (int i = 0; i < 5; i++) {
+    game_core_->PushEventGenerateParticle<particle::Smoke>(
+        position_, rotation_, game_core_->RandomInCircle() * 2.0f, 0.2f,
+        glm::vec4{0.0f, 0.0f, 0.0f, 1.0f}, 3.0f);
+  }
+}
+}  // namespace battle_game::bullet

--- a/src/battle_game/core/bullets/by_chance_bullet.h
+++ b/src/battle_game/core/bullets/by_chance_bullet.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "battle_game/core/bullet.h"
+namespace battle_game::bullet {
+class StrangeBall : public Bullet {
+ public:
+  StrangeBall(GameCore *core,
+             uint32_t id,
+             uint32_t unit_id,
+             uint32_t player_id,
+             glm::vec2 position,
+             float rotation,
+             float damage_scale,
+             glm::vec2 velocity);
+  ~StrangeBall() override;
+  void Render() override;
+  void Update() override;
+ private:
+  glm::vec2 velocity_{};
+};
+}  // namespace battle_game::bullet

--- a/src/battle_game/core/units/tiny_tank.cpp
+++ b/src/battle_game/core/units/tiny_tank.cpp
@@ -137,7 +137,7 @@ void Tank::Fire() {
       auto &input_data = player->GetInputData();
       if (input_data.mouse_button_down[GLFW_MOUSE_BUTTON_LEFT]) {
         auto velocity = Rotate(glm::vec2{0.0f, 20.0f}, turret_rotation_);
-        GenerateBullet<bullet::CannonBall>(
+        GenerateBullet<bullet::StrangeBall>(
             position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
             turret_rotation_, GetDamageScale(), velocity);
         fire_count_down_ = kTickPerSecond;  // Fire interval 1 second.


### PR DESCRIPTION
Close #134 

I have added a new type of bullet to accomplish this feature. Specifically, if this bullet hits the tank's head, it will cause double the damage (which I call a critical hit), otherwise it will only cause the original damage. I modified the bullets fired by Tiny Tank and recorded a video to demonstrate it.


https://github.com/user-attachments/assets/cb28bf95-f658-44eb-bfb1-5b26fef1fb19

