### PR TITLE
feat(unit): Add wasd_tank

### DIFF
--- a/src/battle_game/core/selectable_units.cpp
+++ b/src/battle_game/core/selectable_units.cpp
@@ -22,6 +22,7 @@ void GameCore::GeneratePrimaryUnitList() {
    * TODO: Add Your Unit Here!
    * */
   ADD_SELECTABLE_UNIT(unit::Tank);
+  ADD_SELECTABLE_UNIT(unit::WASDTank);
 
   unit.reset();
 }

--- a/src/battle_game/core/units/wasd_tank.cpp
+++ b/src/battle_game/core/units/wasd_tank.cpp
@@ -1,0 +1,178 @@
+#include "wasd_tank.h"
+
+#include "battle_game/core/bullets/bullets.h"
+#include "battle_game/core/game_core.h"
+#include "battle_game/graphics/graphics.h"
+
+namespace battle_game::unit {
+
+namespace {
+uint32_t tank_body_model_index = 0xffffffffu;
+uint32_t tank_turret_model_index = 0xffffffffu;
+}  // namespace
+
+WASDTank::WASDTank(GameCore *game_core, uint32_t id, uint32_t player_id)
+    : Unit(game_core, id, player_id) {
+  if (!~tank_body_model_index) {
+    auto mgr = AssetsManager::GetInstance();
+    {
+      /* Tank Body */
+      tank_body_model_index = mgr->RegisterModel(
+          {
+              {{-0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              // distinguish front and back
+              {{0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+          },
+          {0, 1, 2, 1, 2, 3, 0, 2, 5, 2, 4, 5});
+    }
+
+    {
+      /* Tank Turret */
+      std::vector<ObjectVertex> turret_vertices;
+      std::vector<uint32_t> turret_indices;
+      const int precision = 60;
+      const float inv_precision = 1.0f / float(precision);
+      for (int i = 0; i < precision; i++) {
+        auto theta = (float(i) + 0.5f) * inv_precision;
+        theta *= glm::pi<float>() * 2.0f;
+        auto sin_theta = std::sin(theta);
+        auto cos_theta = std::cos(theta);
+        turret_vertices.push_back({{sin_theta * 0.5f, cos_theta * 0.5f},
+                                   {0.0f, 0.0f},
+                                   {0.7f, 0.7f, 0.7f, 1.0f}});
+        turret_indices.push_back(i);
+        turret_indices.push_back((i + 1) % precision);
+        turret_indices.push_back(precision);
+      }
+      turret_vertices.push_back(
+          {{0.0f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_indices.push_back(precision + 1 + 0);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 3);
+      tank_turret_model_index =
+          mgr->RegisterModel(turret_vertices, turret_indices);
+    }
+  }
+}
+
+void WASDTank::Render() {
+  battle_game::SetTransformation(position_, rotation_);
+  battle_game::SetTexture(0);
+  battle_game::SetColor(game_core_->GetPlayerColor(player_id_));
+  battle_game::DrawModel(tank_body_model_index);
+  battle_game::SetRotation(turret_rotation_);
+  battle_game::DrawModel(tank_turret_model_index);
+}
+
+void WASDTank::Update() {
+  TankMove(3.0f, glm::radians(180.0f));
+  TurretRotate();
+  Fire();
+}
+
+void WASDTank::TankMove(float move_speed, float rotate_angular_speed) {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    int dx = 0, dy = 0;
+    if (input_data.key_down[GLFW_KEY_W]) {
+      ++dy;
+    }
+    if (input_data.key_down[GLFW_KEY_A]) {
+      --dx;
+    }
+    if (input_data.key_down[GLFW_KEY_S]) {
+      --dy;
+    }
+    if (input_data.key_down[GLFW_KEY_D]) {
+      ++dx;
+    }
+    glm::vec2 offset{0.0f};
+    if (dx || dy) offset.y = 1.0f;
+    float speed = move_speed * GetSpeedScale();
+    offset *= kSecondPerTick * speed;
+    auto new_position =
+        position_ + glm::vec2{glm::rotate(glm::mat4{1.0f}, rotation_,
+                                          glm::vec3{0.0f, 0.0f, 1.0f}) *
+                              glm::vec4{offset, 0.0f, 0.0f}};
+    if (!game_core_->IsBlockedByObstacles(new_position)) {
+      game_core_->PushEventMoveUnit(id_, new_position);
+    }
+    float rotation_offset = 0.0f;
+    if (dx || dy) {
+      float dr = fmodf(atan2f(-dx, dy) - rotation_, glm::pi<float>() * 2);
+      if (dr < 0) dr += glm::pi<float>() * 2;
+      if (dr > ROTATION_EPS && dr < glm::pi<float>() - ROTATION_EPS) {
+        rotation_offset = 1.0f;
+      }
+      if (dr > glm::pi<float>() + ROTATION_EPS && dr < glm::pi<float>() * 2 - ROTATION_EPS) {
+        rotation_offset = -1.0f;
+      }
+    }
+    rotation_offset *= kSecondPerTick * rotate_angular_speed * GetSpeedScale();
+    game_core_->PushEventRotateUnit(id_, rotation_ + rotation_offset);
+  }
+}
+
+void WASDTank::TurretRotate() {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    auto diff = input_data.mouse_cursor_position - position_;
+    if (glm::length(diff) < 1e-4) {
+      turret_rotation_ = rotation_;
+    } else {
+      turret_rotation_ = std::atan2(diff.y, diff.x) - glm::radians(90.0f);
+    }
+  }
+}
+
+void WASDTank::Fire() {
+  if (fire_count_down_ == 0) {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data = player->GetInputData();
+      if (input_data.mouse_button_down[GLFW_MOUSE_BUTTON_LEFT]) {
+        auto velocity = Rotate(glm::vec2{0.0f, 20.0f}, turret_rotation_);
+        GenerateBullet<bullet::CannonBall>(
+            position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
+            turret_rotation_, GetDamageScale(), velocity);
+        fire_count_down_ = kTickPerSecond;  // Fire interval 1 second.
+      }
+    }
+  }
+  if (fire_count_down_) {
+    fire_count_down_--;
+  }
+}
+
+bool WASDTank::IsHit(glm::vec2 position) const {
+  position = WorldToLocal(position);
+  return position.x > -0.8f && position.x < 0.8f && position.y > -1.0f &&
+         position.y < 1.0f && position.x + position.y < 1.6f &&
+         position.y - position.x < 1.6f;
+}
+
+const char *WASDTank::UnitName() const {
+  return "WASD Tank";
+}
+
+const char *WASDTank::Author() const {
+  return "Early";
+}
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/wasd_tank.h
+++ b/src/battle_game/core/units/wasd_tank.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "battle_game/core/unit.h"
+
+namespace battle_game::unit {
+class WASDTank : public Unit {
+ public:
+  WASDTank(GameCore *game_core, uint32_t id, uint32_t player_id);
+  void Render() override;
+  void Update() override;
+  [[nodiscard]] bool IsHit(glm::vec2 position) const override;
+
+ protected:
+  static constexpr float ROTATION_EPS = 1e-2f;
+
+  void TankMove(float move_speed, float rotate_angular_speed);
+  void TurretRotate();
+  void Fire();
+  [[nodiscard]] const char *UnitName() const override;
+  [[nodiscard]] const char *Author() const override;
+
+  float turret_rotation_{0.0f};
+  uint32_t fire_count_down_{0};
+  uint32_t mine_count_down_{0};
+};
+}  // namespace battle_game::unit


### PR DESCRIPTION
从小就觉得坦克大战中 `W` 前进、`S` 后退、`A` `D` 转向的操作很反人类！因此，我们新增了 wasd_tank——
- 现在，`W` `S` `A` `D` 分别对应向上、向下、向左、向右移动啦
- 为了保持坦克大战的原汁原味，仍然设置了转向速度的限制，坦克会尽量迅速地转到你想要的方向
- 支持八个方位：例如同时按下 `W` `A` 即可向左上移动
- ~为保证游戏平衡性，子弹射击功能暂未作出调整~

这一次，即使手残的你也定能驾驶 wasd_tank 大杀四方！

这是一张 wasd_tank 向左下方行进的图片：
![wasd_tank](https://github.com/user-attachments/assets/87e09712-ac33-4fd1-8183-081cfecd1c54)